### PR TITLE
Move the maven-publish plugin further down.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,8 +14,6 @@ release {
     grgit = Grgit.open(projectDir)
 }
 
-apply plugin: 'maven-publish'
-
 ext {
     isSnapshot = version.toString().contains("-dev")
 }
@@ -42,6 +40,10 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
     classifier = 'javadoc'
     from javadoc.destinationDir
 }
+
+// Must be configured late because of interactions with the release plugin above
+//    > Cannot configure the 'publishing' extension after it has been accessed.
+apply plugin: 'maven-publish'
 
 artifacts {
     archives sourcesJar


### PR DESCRIPTION
$ gradle idea
    Inferred project: unacceptable, version: 0.0.1-dev.7+2107481

    FAILURE: Build failed with an exception.

    * Where:
    Build file '/Users/owen/Development/unacceptable/unacceptable/build.gradle' line: 51

    * What went wrong:
    A problem occurred evaluating root project 'unacceptable'.
    > Cannot configure the 'publishing' extension after it has been accessed.