### PR TITLE
Eliminate Javadoc warnings in SeleniumDriver.

### DIFF
--- a/unacceptable-selenium/src/main/java/io/github/unacceptable/selenium/driver/SeleniumDriver.java
+++ b/unacceptable-selenium/src/main/java/io/github/unacceptable/selenium/driver/SeleniumDriver.java
@@ -30,21 +30,14 @@ public abstract class SeleniumDriver {
      * Shorthand for <code>webDriver().findElement(by)</code>. This is a common case in Selenium-based tests, and saving
      * some keystrokes helps.
      *
+     * @param by
+     *         the selector to search for on the current page.
+     * @return the matching {@link WebElement} collection.
      * @see #webDriver()
      * @see org.openqa.selenium.WebDriver#findElement(org.openqa.selenium.By)
      */
     protected WebElement findElement(By by) {
         return webDriver()
                 .findElement(by);
-    }
-
-    /**
-     * Shorthand for <code>findElement(By.tagName("h1"))</code>. This is a common case for inspecting the page's title
-     * heading.
-     *
-     * @see #findElement(org.openqa.selenium.By)
-     */
-    protected WebElement findPageHeading() {
-        return findElement(By.tagName("h1"));
     }
 }


### PR DESCRIPTION
The `findPageHeading()` finder method is a hangover from Login Box.