### PR TITLE
Provide a context that manages access to a Dropwizard app.

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,6 @@ rootProject.name = 'unacceptable'
 
 include 'unacceptable-aliases'
 include 'unacceptable-database'
+include 'unacceptable-dropwizard'
 include 'unacceptable-lazy'
 include 'unacceptable-selenium'

--- a/unacceptable-database/src/main/java/io/github/unacceptable/database/DatabaseContext.java
+++ b/unacceptable-database/src/main/java/io/github/unacceptable/database/DatabaseContext.java
@@ -12,6 +12,8 @@ import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
+import static io.github.unacceptable.lazy.Lazily.systemProperty;
+
 /**
  * Manages a temporary testing database during a test. This makes a few assumptions about the structure of your
  * database:
@@ -42,9 +44,7 @@ public class DatabaseContext {
      * @return the JDBC URL to use when making administrative connections to the database.
      */
     public String adminUrl() {
-        return adminUrl = Lazily.create(
-                adminUrl,
-                () -> System.getProperty("database.adminUrl", defaultAdminUrl()));
+        return adminUrl = systemProperty(adminUrl, "database.adminUrl", this::defaultAdminUrl);
     }
 
     protected String defaultAdminUrl() {
@@ -56,7 +56,7 @@ public class DatabaseContext {
      * databases.
      */
     public String username() {
-        return username = Lazily.create(username, () -> System.getProperty("database.username", defaultUsername()));
+        return username = systemProperty(username, "database.username", this::defaultUsername);
     }
 
     protected String defaultUsername() {
@@ -67,7 +67,7 @@ public class DatabaseContext {
      * @return the password to connect to the database server with, if any.
      */
     public String password() {
-        return password = Lazily.create(password, () -> System.getProperty("database.password", defaultPassword()));
+        return password = systemProperty(password, "database.password", this::defaultPassword);
     }
 
     protected String defaultPassword() {
@@ -86,7 +86,7 @@ public class DatabaseContext {
      * @return the template to use when {@link #databaseName() computing the database name}.
      */
     public String templateDatabaseName() {
-        return template = Lazily.create(template, () -> System.getProperty("database.nameTemplate", defaultTemplateDatabaseName()));
+        return template = systemProperty(template, "database.nameTemplate", this::defaultTemplateDatabaseName);
     }
 
     protected String defaultTemplateDatabaseName() {

--- a/unacceptable-dropwizard/build.gradle
+++ b/unacceptable-dropwizard/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     }
 
     compile project(':unacceptable-lazy')
+    compile project(':unacceptable-selenium')
     compile group: 'io.dropwizard', name: 'dropwizard-testing', version: dropwizardVersion
     compile group: 'junit', name: 'junit', version: '4.12'
 

--- a/unacceptable-dropwizard/build.gradle
+++ b/unacceptable-dropwizard/build.gradle
@@ -1,0 +1,15 @@
+dependencies {
+    ext {
+        dropwizardVersion = '0.9.1'
+        hamcrestVersion = '1.3'
+    }
+
+    compile project(':unacceptable-lazy')
+    compile group: 'io.dropwizard', name: 'dropwizard-testing', version: dropwizardVersion
+    compile group: 'junit', name: 'junit', version: '4.12'
+
+    testCompile group: 'com.jayway.restassured', name: 'rest-assured', version: '2.7.0'
+    testCompile group: 'org.hamcrest', name: 'hamcrest-core', version: hamcrestVersion
+    testCompile group: 'org.hamcrest', name: 'hamcrest-library', version: hamcrestVersion
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '1.10.19'
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
@@ -1,0 +1,111 @@
+package io.github.unacceptable.dropwizard.context;
+
+import com.google.common.collect.ObjectArrays;
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.ConfigOverride;
+import io.github.unacceptable.lazy.Lazily;
+import org.junit.rules.TestRule;
+
+import static io.github.unacceptable.lazy.Lazily.systemProperty;
+
+/**
+ * Starts a Dropwizard application around each test run, unless a previously-running application's URL has been
+ * provided.
+ * <p>
+ * To target tests to an existing app, set the {@code app.url} system property. If not set, this context will boot an
+ * instance of {@link #mainClass() your application} for the duration of the test, then shut it down.
+ * <p>
+ * When booting an application, the {@link #overrides() configuration overrides} will be applied. By default, the only
+ * override applied sets the logging level to {@link #logLevel()}, which will suppress the vast sea of bootup and
+ * shutdown diagnostic messages. However, additional overrides can be supplied via the {@link #extraOverrides()} method,
+ * or the complete overrides list can be customized by overriding {@link #overrides()} directly.
+ */
+public abstract class ApplicationContext<C extends Configuration> {
+    private ApplicationState<C> applicationState = null;
+    private String logLevel = null;
+
+    private ApplicationState<C> applicationState() {
+        return applicationState = Lazily.create(applicationState, this::detectApplicationState);
+    }
+
+    private ApplicationState<C> detectApplicationState() {
+        String appUrl = System.getProperty("app.url");
+        if (appUrl == null) {
+            return new OneShotApplicationState<C>() {
+                @Override
+                protected ConfigOverride[] overrides() {
+                    return ApplicationContext.this.overrides();
+                }
+
+                @Override
+                protected Class<? extends Application<C>> mainClass() {
+                    return ApplicationContext.this.mainClass();
+                }
+            };
+        }
+        return new ExternalApplicationState<>(appUrl);
+    }
+
+    /**
+     * @return the application's base URL.
+     */
+    public String url() {
+        return applicationState()
+                .url();
+    }
+
+    /**
+     * @param path
+     *         a path relative to the application root.
+     * @return the absolute URL of the same path within the application.
+     */
+    public String url(String path) {
+        String baseUrl = Strings.stripTrailingSlashes(url());
+        path = Strings.stripLeadingSlashes(path);
+
+        return String.format("%s/%s", baseUrl, path);
+    }
+
+    /**
+     * @return the log threshold of the app booted by this context, or the {@code app.log.level} system property.
+     */
+    public String logLevel() {
+        return logLevel = systemProperty(logLevel, "app.log.level", this::defaultLogThreshold);
+    }
+
+    /**
+     * @return the default log threshold to use if the {@code app.log.level} property is not set.
+     */
+    protected String defaultLogThreshold() {
+        return "WARN";
+    }
+
+    /**
+     * @return if the app must be booted by this context, then this rule will ensure that the app is booted and torn
+     * down.
+     */
+    public TestRule rules() {
+        return applicationState()
+                .rules();
+    }
+
+    protected ConfigOverride[] overrides() {
+        ConfigOverride[] defaultOverrides = defaultOverrides();
+        ConfigOverride[] extraOverrides = extraOverrides();
+
+        return ObjectArrays.concat(defaultOverrides, extraOverrides, ConfigOverride.class);
+    }
+
+    private ConfigOverride[] defaultOverrides() {
+        return new ConfigOverride[]{
+                ConfigOverride.config("logging.level", logLevel()),
+        };
+    }
+
+    protected ConfigOverride[] extraOverrides() {
+        return new ConfigOverride[]{};
+    }
+
+    protected abstract Class<? extends Application<C>> mainClass();
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationState.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationState.java
@@ -1,0 +1,10 @@
+package io.github.unacceptable.dropwizard.context;
+
+import io.dropwizard.Configuration;
+import org.junit.rules.TestRule;
+
+interface ApplicationState<C extends Configuration> {
+    public String url();
+
+    public TestRule rules();
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ExternalApplicationState.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ExternalApplicationState.java
@@ -1,0 +1,26 @@
+package io.github.unacceptable.dropwizard.context;
+
+import io.dropwizard.Configuration;
+import org.junit.rules.ExternalResource;
+import org.junit.rules.TestRule;
+
+class ExternalApplicationState<C extends Configuration> implements ApplicationState<C> {
+    private final String appUrl;
+
+    public ExternalApplicationState(String appUrl) {
+        this.appUrl = appUrl;
+    }
+
+    @Override
+    public String url() {
+        return appUrl;
+    }
+
+    @Override
+    public TestRule rules() {
+        return new NoOpRule();
+    }
+
+    private class NoOpRule extends ExternalResource {
+    }
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/OneShotApplicationState.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/OneShotApplicationState.java
@@ -1,0 +1,44 @@
+package io.github.unacceptable.dropwizard.context;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import io.github.unacceptable.lazy.Lazily;
+
+abstract class OneShotApplicationState<C extends Configuration> implements ApplicationState<C> {
+    private DropwizardAppRule<C> rules = null;
+    private String appUrl = null;
+
+    @Override
+    public String url() {
+        return appUrl = Lazily.create(appUrl, this::appUrlFromRule);
+    }
+
+    private String appUrlFromRule() {
+        DropwizardAppRule<C> appRule = rules();
+        int port = appRule.getLocalPort();
+        String appUrl = appUrlFromPort(port);
+        return appUrl;
+    }
+
+    private String appUrlFromPort(int localPort) {
+        return String.format("http://localhost:%d/", localPort);
+    }
+
+    @Override
+    public DropwizardAppRule<C> rules() {
+        return rules = Lazily.create(rules, this::newAppRule);
+    }
+
+    private DropwizardAppRule<C> newAppRule() {
+        Class<? extends Application<C>> mainClass = mainClass();
+        String configPath = null;
+        ConfigOverride[] overrides = overrides();
+        return new DropwizardAppRule<C>(mainClass, configPath, overrides);
+    }
+
+    protected abstract ConfigOverride[] overrides();
+
+    protected abstract Class<? extends Application<C>> mainClass();
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/Strings.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/Strings.java
@@ -1,0 +1,28 @@
+package io.github.unacceptable.dropwizard.context;
+
+class Strings {
+    public static String stripLeadingSlashes(String s) {
+        int i = findFirstNonSlash(s);
+        return s.substring(i);
+    }
+
+    public static String stripTrailingSlashes(String s) {
+        int i = findLastNonSlash(s);
+        return s.substring(0, i);
+    }
+
+    public static int findLastNonSlash(String s) {
+        for (int i = s.length(); i > 0; --i)
+            if (s.charAt(i - 1) != '/')
+                return i;
+        return 0;
+    }
+
+    public static int findFirstNonSlash(String s) {
+        for (int i = 0; i < s.length(); ++i)
+            if (s.charAt(i) != '/')
+                return i;
+        return s.length();
+    }
+
+}

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/Strings.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/Strings.java
@@ -11,14 +11,14 @@ class Strings {
         return s.substring(0, i);
     }
 
-    public static int findLastNonSlash(String s) {
+    private static int findLastNonSlash(String s) {
         for (int i = s.length(); i > 0; --i)
             if (s.charAt(i - 1) != '/')
                 return i;
         return 0;
     }
 
-    public static int findFirstNonSlash(String s) {
+    private static int findFirstNonSlash(String s) {
         for (int i = 0; i < s.length(); ++i)
             if (s.charAt(i) != '/')
                 return i;

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/driver/SeleniumDriver.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/driver/SeleniumDriver.java
@@ -1,0 +1,17 @@
+package io.github.unacceptable.dropwizard.driver;
+
+import io.github.unacceptable.dropwizard.context.ApplicationContext;
+import io.github.unacceptable.selenium.context.SeleniumContext;
+
+/**
+ * A Selenium driver associated with a specific ApplicationContext. In addition to the basic SeleniumDriver features,
+ * this also provides convenient access to the ApplicationContext to its subclasses and clients.
+ */
+public class SeleniumDriver extends io.github.unacceptable.selenium.driver.SeleniumDriver {
+    protected final ApplicationContext<?> app;
+
+    public SeleniumDriver(SeleniumContext context, ApplicationContext<?> app) {
+        super(context);
+        this.app = app;
+    }
+}

--- a/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
+++ b/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
@@ -1,0 +1,117 @@
+package io.github.unacceptable.dropwizard.context;
+
+import io.dropwizard.Application;
+import io.dropwizard.Configuration;
+import io.dropwizard.setup.Environment;
+import io.dropwizard.testing.junit.DropwizardAppRule;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+import static com.jayway.restassured.RestAssured.get;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.spy;
+
+public class ApplicationContextTest {
+    @Before
+    public void configureProperties() {
+        System.clearProperty("app.url");
+    }
+
+    public static class TestConfig extends Configuration {
+    }
+
+    @Path("/hello")
+    public static class TestResource {
+        @GET
+        public String hello() {
+            return "Hello, world.";
+        }
+    }
+
+    public static class TestApp extends Application<TestConfig> {
+        @Override
+        public void run(TestConfig configuration, Environment environment) throws Exception {
+            environment.jersey().register(TestResource.class);
+        }
+    }
+
+    @Test
+    public void urlPaths() {
+        ApplicationContext<TestConfig> applicationContext = spy(new ApplicationContext<TestConfig>() {
+            @Override
+            protected Class<? extends Application<TestConfig>> mainClass() {
+                return TestApp.class;
+            }
+        });
+        doReturn("https://app.example.com/").when(applicationContext).url();
+
+        assertThat(
+                applicationContext.url("/path/to/resource"),
+                equalTo("https://app.example.com/path/to/resource"));
+        assertThat(
+                applicationContext.url("path/to/resource"),
+                equalTo("https://app.example.com/path/to/resource"));
+        assertThat( // surprise!
+                applicationContext.url("//////////path/to/resource/"),
+                equalTo("https://app.example.com/path/to/resource/"));
+    }
+
+    @Test
+    public void detectsOneShotApp() throws Throwable {
+        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<TestConfig>() {
+            @Override
+            protected Class<? extends Application<TestConfig>> mainClass() {
+                return TestApp.class;
+            }
+        };
+
+        assertThat(
+                applicationContext.rules(),
+                instanceOf(DropwizardAppRule.class));
+        applicationContext
+                .rules()
+                .apply(
+                        new Statement() {
+                            @Override
+                            public void evaluate() throws Throwable {
+                                assertThat(
+                                        applicationContext.url(),
+                                        startsWith("http://localhost:"));
+                                get(applicationContext.url("/hello"))
+                                        .then()
+                                        .body(equalTo("Hello, world."));
+                            }
+                        },
+                        Description.createSuiteDescription(getClass()))
+                .evaluate();
+        ;
+    }
+
+    @Test
+    public void detectsExistingApp() {
+        System.setProperty("app.url", "https://example.com/");
+        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<TestConfig>() {
+            @Override
+            protected Class<? extends Application<TestConfig>> mainClass() {
+                return TestApp.class;
+            }
+        };
+
+        assertThat(
+                applicationContext.rules(),
+                not(instanceOf(DropwizardAppRule.class)));
+        assertThat(
+                applicationContext.url(),
+                equalTo("https://example.com/"));
+    }
+}

--- a/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
+++ b/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
@@ -84,9 +84,6 @@ public class ApplicationContextTest {
                         new Statement() {
                             @Override
                             public void evaluate() throws Throwable {
-                                assertThat(
-                                        applicationContext.url(),
-                                        startsWith("http://localhost:"));
                                 get(applicationContext.url("/hello"))
                                         .then()
                                         .body(equalTo("Hello, world."));

--- a/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/StringsTest.java
+++ b/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/StringsTest.java
@@ -1,0 +1,50 @@
+package io.github.unacceptable.dropwizard.context;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+public class StringsTest {
+
+    @Test
+    public void stripLeadingSlashes() {
+        assertThat(Strings.stripLeadingSlashes(""), equalTo(""));
+        assertThat(Strings.stripLeadingSlashes("/"), equalTo(""));
+        assertThat(Strings.stripLeadingSlashes("////"), equalTo(""));
+        assertThat(Strings.stripLeadingSlashes("foo"), equalTo("foo"));
+        assertThat(Strings.stripLeadingSlashes("/foo/"), equalTo("foo/"));
+        assertThat(Strings.stripLeadingSlashes("/////foo/bar"), equalTo("foo/bar"));
+    }
+
+    @Test
+    public void stripTrailingSlashes() {
+        assertThat(Strings.stripTrailingSlashes(""), equalTo(""));
+        assertThat(Strings.stripTrailingSlashes("/"), equalTo(""));
+        assertThat(Strings.stripTrailingSlashes("////"), equalTo(""));
+        assertThat(Strings.stripTrailingSlashes("foo"), equalTo("foo"));
+        assertThat(Strings.stripTrailingSlashes("/foo/"), equalTo("/foo"));
+        assertThat(Strings.stripTrailingSlashes("foo/bar/////"), equalTo("foo/bar"));
+    }
+
+    @Test
+    public void findLastNonSlash() {
+        assertThat(Strings.findLastNonSlash(""), equalTo(0));
+        assertThat(Strings.findLastNonSlash("/"), equalTo(0));
+        assertThat(Strings.findLastNonSlash("////"), equalTo(0));
+        assertThat(Strings.findLastNonSlash("foo"), equalTo(3));
+        assertThat(Strings.findLastNonSlash("/foo/"), equalTo(4));
+        assertThat(Strings.findLastNonSlash("foo/bar/////"), equalTo(7));
+
+    }
+
+    @Test
+    public void findFirstNonSlash() {
+        assertThat(Strings.findFirstNonSlash(""), equalTo(0));
+        assertThat(Strings.findFirstNonSlash("/"), equalTo(1));
+        assertThat(Strings.findFirstNonSlash("////"), equalTo(4));
+        assertThat(Strings.findFirstNonSlash("foo"), equalTo(0));
+        assertThat(Strings.findFirstNonSlash("/foo/"), equalTo(1));
+        assertThat(Strings.findFirstNonSlash("foo/bar/////"), equalTo(0));
+    }
+}

--- a/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/StringsTest.java
+++ b/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/StringsTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class StringsTest {
-
     @Test
     public void stripLeadingSlashes() {
         assertThat(Strings.stripLeadingSlashes(""), equalTo(""));
@@ -25,26 +24,5 @@ public class StringsTest {
         assertThat(Strings.stripTrailingSlashes("foo"), equalTo("foo"));
         assertThat(Strings.stripTrailingSlashes("/foo/"), equalTo("/foo"));
         assertThat(Strings.stripTrailingSlashes("foo/bar/////"), equalTo("foo/bar"));
-    }
-
-    @Test
-    public void findLastNonSlash() {
-        assertThat(Strings.findLastNonSlash(""), equalTo(0));
-        assertThat(Strings.findLastNonSlash("/"), equalTo(0));
-        assertThat(Strings.findLastNonSlash("////"), equalTo(0));
-        assertThat(Strings.findLastNonSlash("foo"), equalTo(3));
-        assertThat(Strings.findLastNonSlash("/foo/"), equalTo(4));
-        assertThat(Strings.findLastNonSlash("foo/bar/////"), equalTo(7));
-
-    }
-
-    @Test
-    public void findFirstNonSlash() {
-        assertThat(Strings.findFirstNonSlash(""), equalTo(0));
-        assertThat(Strings.findFirstNonSlash("/"), equalTo(1));
-        assertThat(Strings.findFirstNonSlash("////"), equalTo(4));
-        assertThat(Strings.findFirstNonSlash("foo"), equalTo(0));
-        assertThat(Strings.findFirstNonSlash("/foo/"), equalTo(1));
-        assertThat(Strings.findFirstNonSlash("foo/bar/////"), equalTo(0));
     }
 }

--- a/unacceptable-lazy/src/main/java/io/github/unacceptable/lazy/Lazily.java
+++ b/unacceptable-lazy/src/main/java/io/github/unacceptable/lazy/Lazily.java
@@ -26,8 +26,38 @@ public class Lazily {
      * @return either <var>value</var> or a new object from <var>initialiser</var>.
      */
     public static <T> T create(T value, Supplier<? extends T> initialiser) {
-        if (value == null)
-            return initialiser.get();
-        return value;
+        if (value != null)
+            return value;
+        return initialiser.get();
+    }
+
+    /**
+     * Lazy-init helper for values obtained from {@link System#getProperty(String, String) system properties}. If the
+     * first argument is non-null, it will be returned as is. Otherwise, if the named property is set, its value will be
+     * returned. Otherwise, the value of the default callback will be returned. <p> The default callback is guaranteed
+     * not to be invoked unless its value is needed. <p> The intended usage pattern:
+     * <pre>
+     *     public String filename() {
+     *         return this.filename = Lazily.systemProperty(this.filename, "file.name", this::defaultFilename);
+     *     }
+     * </pre>
+     * <p> You can also pass a lambda or a pre-existing {@link Supplier} instead of a method handle. </p>
+     *
+     * @param value
+     *         the initializable field's current value.
+     * @param property
+     *         the name of the system property to read.
+     * @param defaultCallback
+     *         a factory for creating the default value if neither the current value nor a system property are set.
+     * @return either <var>value</var>, or the value of the named system property, or the result of invoking the default
+     * callback.
+     */
+    public static String systemProperty(String value, String property, Supplier<? extends String> defaultCallback) {
+        if (value != null)
+            return value;
+        value = System.getProperty(property);
+        if (value != null)
+            return value;
+        return defaultCallback.get();
     }
 }

--- a/unacceptable-lazy/src/test/java/io/github/unacceptable/lazy/LazilyTest.java
+++ b/unacceptable-lazy/src/test/java/io/github/unacceptable/lazy/LazilyTest.java
@@ -1,21 +1,51 @@
 package io.github.unacceptable.lazy;
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 
 public class LazilyTest {
+    @Before
+    public void setKnownProperties() {
+        System.setProperty(
+                "io.github.unacceptable.lazy.set",
+                "property value");
+        System.clearProperty("io.github.unacceptable.lazy.unset");
+    }
+
     @Test
-    public void withExisting() {
+    public void createWithExisting() {
         String value = Lazily.create("known", this::failOnGet);
 
         assertThat(value, equalTo("known"));
     }
 
     @Test
-    public void newValue() {
+    public void createNewValue() {
         String value = Lazily.create(null, () -> "new value");
+
+        assertThat(value, equalTo("new value"));
+    }
+
+    @Test
+    public void systemPropertyWithExisting() {
+        String value = Lazily.systemProperty("known", "io.github.unacceptable.lazy.unset", this::failOnGet);
+
+        assertThat(value, equalTo("known"));
+    }
+
+    @Test
+    public void systemPropertyFromProperty() {
+        String value = Lazily.systemProperty(null, "io.github.unacceptable.lazy.set", this::failOnGet);
+
+        assertThat(value, equalTo("property value"));
+    }
+
+    @Test
+    public void systemPropertyFromDefault() {
+        String value = Lazily.systemProperty(null, "io.github.unacceptable.lazy.unset", () -> "new value");
 
         assertThat(value, equalTo("new value"));
     }


### PR DESCRIPTION
If `app.url` is set, tests using this context will talk to the app at that
URL.

Otherwise, tests using this context will spin up a temporary app for each
test, and shut it down at the end of each test.