### PR TITLE
Warnings are hard errors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,12 @@ subprojects {
 
     sourceCompatibility = '1.8'
 
+    tasks.withType(JavaCompile) {
+        options.encoding = 'UTF-8'
+        options.compilerArgs << '-Xlint:all'
+        options.compilerArgs << '-Werror'
+    }
+
     task sourcesJar(type: Jar, dependsOn: classes) {
         classifier = 'sources'
         from sourceSets.main.allSource


### PR DESCRIPTION
Special cases should be `@SuppressWarning`'d at the site, with a comment explaining why this specific case is permissible. The build should output cleanly, so that novel mistakes can be spotted easily.

(I actually violated this on a branch, to my chagrin.)