### PR TITLE
Modifying the way ApplicationContext works to not require extending.

### DIFF
--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
@@ -1,6 +1,7 @@
 package io.github.unacceptable.dropwizard.context;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ObjectArrays;
 import io.dropwizard.Application;
 import io.dropwizard.Configuration;
 import io.dropwizard.testing.ConfigOverride;
@@ -127,9 +128,9 @@ public class ApplicationContext<C extends Configuration> {
     }
 
     private ConfigOverride[] appendLogLevelOverride(final ConfigOverride[] configOverrides) {
-        final ConfigOverride[] merged = Arrays.copyOf(configOverrides, configOverrides.length+1);
-        merged[merged.length-1] = ConfigOverride.config("logging.level", logLevel());
-        return merged;
+        return ObjectArrays.concat(
+                ConfigOverride.config("logging.level", logLevel()),
+                configOverrides);
     }
 
 }

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/ApplicationContext.java
@@ -34,16 +34,31 @@ public class ApplicationContext<C extends Configuration> {
     private ApplicationState<C> applicationState = null;
     private String logLevel = null;
 
+    /**
+     * Create a context by specifying only the dropwizard {@link Application} subclass.  This will use a null
+     * configuration path, and only the default configuration override for logging level.
+     * Effectively, this delegates to the similar {@link io.dropwizard.testing.junit.DropwizardAppRule} constructor.
+     */
     public ApplicationContext(Class<? extends Application<C>> applicationClass) {
         this(applicationClass, (String) null);
     }
 
+    /**
+     * Create a context by specifying the dropwizard {@link Application} subclass, a (nullable) configuration path,
+     * and an optional list of configuration overrides.  These config overrides will have the default log level
+     * override added to them, but can override it.
+     * Effectively, this delegates to the similar {@link io.dropwizard.testing.junit.DropwizardAppRule} constructor.
+     */
     public ApplicationContext(Class<? extends Application<C>> applicationClass,
                               @Nullable String configPath,
                               ConfigOverride... configOverrides) {
         this(applicationClass, configPath, Optional.<String>absent(), configOverrides);
     }
 
+    /**
+     * Create a context similarily to the previous constructor, but with a custom property prefix.
+     * Effectively, this delegates to the similar {@link io.dropwizard.testing.junit.DropwizardAppRule} constructor.
+     */
     public ApplicationContext(Class<? extends Application<C>> applicationClass, String configPath,
                               Optional<String> customPropertyPrefix, ConfigOverride... configOverrides) {
         this.applicationClass = applicationClass;

--- a/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/OneShotApplicationState.java
+++ b/unacceptable-dropwizard/src/main/java/io/github/unacceptable/dropwizard/context/OneShotApplicationState.java
@@ -1,14 +1,18 @@
 package io.github.unacceptable.dropwizard.context;
 
-import io.dropwizard.Application;
 import io.dropwizard.Configuration;
-import io.dropwizard.testing.ConfigOverride;
+import io.dropwizard.testing.DropwizardTestSupport;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import io.github.unacceptable.lazy.Lazily;
 
-abstract class OneShotApplicationState<C extends Configuration> implements ApplicationState<C> {
+public class OneShotApplicationState<C extends Configuration> implements ApplicationState<C> {
     private DropwizardAppRule<C> rules = null;
     private String appUrl = null;
+    private final DropwizardTestSupport<C> testSupport;
+
+    public OneShotApplicationState(final DropwizardTestSupport<C> testSupport) {
+        this.testSupport = testSupport;
+    }
 
     @Override
     public String url() {
@@ -32,13 +36,7 @@ abstract class OneShotApplicationState<C extends Configuration> implements Appli
     }
 
     private DropwizardAppRule<C> newAppRule() {
-        Class<? extends Application<C>> mainClass = mainClass();
-        String configPath = null;
-        ConfigOverride[] overrides = overrides();
-        return new DropwizardAppRule<C>(mainClass, configPath, overrides);
+        return new DropwizardAppRule<C>(testSupport);
     }
 
-    protected abstract ConfigOverride[] overrides();
-
-    protected abstract Class<? extends Application<C>> mainClass();
 }

--- a/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
+++ b/unacceptable-dropwizard/src/test/java/io/github/unacceptable/dropwizard/context/ApplicationContextTest.java
@@ -47,12 +47,7 @@ public class ApplicationContextTest {
 
     @Test
     public void urlPaths() {
-        ApplicationContext<TestConfig> applicationContext = spy(new ApplicationContext<TestConfig>() {
-            @Override
-            protected Class<? extends Application<TestConfig>> mainClass() {
-                return TestApp.class;
-            }
-        });
+        ApplicationContext<TestConfig> applicationContext = spy(new ApplicationContext<>(TestApp.class));
         doReturn("https://app.example.com/").when(applicationContext).url();
 
         assertThat(
@@ -68,12 +63,7 @@ public class ApplicationContextTest {
 
     @Test
     public void detectsOneShotApp() throws Throwable {
-        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<TestConfig>() {
-            @Override
-            protected Class<? extends Application<TestConfig>> mainClass() {
-                return TestApp.class;
-            }
-        };
+        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<>(TestApp.class);
 
         assertThat(
                 applicationContext.rules(),
@@ -97,12 +87,7 @@ public class ApplicationContextTest {
     @Test
     public void detectsExistingApp() {
         System.setProperty("app.url", "https://example.com/");
-        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<TestConfig>() {
-            @Override
-            protected Class<? extends Application<TestConfig>> mainClass() {
-                return TestApp.class;
-            }
-        };
+        ApplicationContext<TestConfig> applicationContext = new ApplicationContext<>(TestApp.class);
 
         assertThat(
                 applicationContext.rules(),


### PR DESCRIPTION
The constructors mirror some of those from DropwizardAppRule, so anyone familiar with that should be able to use an ApplicationContext in it's place.