### PR TITLE
Automatically deploy `master` builds to Bintray snapshots.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -12,3 +12,9 @@ test:
     post:
         - ./gradlew javadoc
         - bin/collate-test-results "$CIRCLE_TEST_REPORTS"
+
+deployment:
+    snapshots:
+        branch: master
+        commands:
+            - ./gradlew bintrayUpload


### PR DESCRIPTION
This way, the latest canonical build is actually available _somewhere_.

This'll require adjusting the CircleCI configuration as well.